### PR TITLE
extension: Fix codelens detection and activating extension on yaml open

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "redhat.vscode-yaml"
   ],
   "activationEvents": [
-    "onDebug:dalec-buildx"
+    "onDebug:dalec-buildx",
+    "onLanguage:yaml",
+    "workspaceContains:**/*.yaml",
+    "workspaceContains:**/*.yml"
   ],
   "preview": true,
   "main": "./dist/extension.js",

--- a/src/commands/runBuildCurrentSpecCommand/runBuildCommand.ts
+++ b/src/commands/runBuildCurrentSpecCommand/runBuildCommand.ts
@@ -124,13 +124,13 @@ export class DalecCodeLensProvider implements vscode.CodeLensProvider, vscode.Di
     if (last && last.specUri.toString() === document.uri.toString()) {
       lenses.push(
         new vscode.CodeLens(range, {
-          command: 'dalec.rerunLastActionDebug',
+          command: 'dalec-vscode-tools.rerunLastActionDebug',
           title: `Dalec: Debug (${last.target})`,
         }),
       );
       lenses.push(
         new vscode.CodeLens(range, {
-          command: 'dalec.rerunLastActionBuild',
+          command: 'dalec-vscode-tools.rerunLastActionBuild',
           title: `Dalec: Build (${last.target})`,
         }),
       );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,6 +61,9 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('dalec-vscode-tools.rerunLastActionBuild', () =>
       rerunLastAction(tracker, lastAction, 'build'),
     ),
+    vscode.commands.registerCommand('dalec-vscode-tools.rerunLastActionDebug', () =>
+      rerunLastAction(tracker, lastAction, 'debug'),
+    ),
 
 	context.subscriptions.push(disposable);
 }


### PR DESCRIPTION
Fixes
Extension doesn't activate on YAML open
Command dalec.rerunLastActionDebug not registered
CodeLens uses wrong command names

<img width="536" height="102" alt="Screenshot 2025-12-23 at 5 22 57 PM" src="https://github.com/user-attachments/assets/3b1dba6f-310a-4232-9933-f97d4f6e7751" />
