### PR TITLE
Add debug command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -492,6 +492,7 @@
       "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -946,6 +947,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1175,6 +1177,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1663,6 +1666,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3432,6 +3436,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3863,6 +3868,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3936,6 +3942,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4058,6 +4065,7 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -4107,6 +4115,7 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
         "title": "Dalec: Build Current Spec"
       },
       {
+        "command": "dalec-vscode-tools.debugCurrentSpec",
+        "title": "Dalec: Debug Current Spec"
+      },
+      {
         "command": "dalec-vscode-tools.rerunLastAction",
         "title": "Dalec: Rerun Last Action"
       }
@@ -39,6 +43,11 @@
           "command": "dalec-vscode-tools.buildCurrentSpec",
           "when": "resourceLangId == yaml",
           "group": "navigation"
+        },
+        {
+          "command": "dalec-vscode-tools.debugCurrentSpec",
+          "when": "resourceLangId == yaml",
+          "group": "navigation"
         }
       ],
       "explorer/context": [
@@ -46,14 +55,14 @@
           "command": "dalec-vscode-tools.buildCurrentSpec",
           "when": "resourceLangId == yaml",
           "group": "navigation"
+        },
+        {
+          "command": "dalec-vscode-tools.debugCurrentSpec",
+          "when": "resourceLangId == yaml",
+          "group": "navigation"
         }
       ]
     },
-    "breakpoints": [
-      {
-        "language": "yaml"
-      }
-    ],
     "configuration": {
       "title": "Dalec Spec",
       "properties": {
@@ -83,11 +92,6 @@
       {
         "type": "dalec-buildx",
         "label": "Dalec Buildx (docker buildx dap)",
-        "enableBreakpointsFor": [
-          {
-            "language": "yaml"
-          }
-        ],
         "configurationAttributes": {
           "launch": {
             "required": [

--- a/src/commands/reRunLastAction/reRunLastAction.ts
+++ b/src/commands/reRunLastAction/reRunLastAction.ts
@@ -6,6 +6,7 @@ import { BuildTargetInfo } from '../runBuildCurrentSpecCommand/helpers/targetHel
 import { getWorkspaceRootForUri } from '../runBuildCurrentSpecCommand/utils/pathHelpers';
 import { ArgsSelection, collectArgsSelection, collectContextSelection, ContextSelection } from '../runBuildCurrentSpecCommand/helpers/contextHelpers';
 import { createDockerBuildxCommand, logDockerCommand } from '../runBuildCurrentSpecCommand/utils/dockerHelpers';
+import { recordFromMap } from '../runBuildCurrentSpecCommand/utils/conversionHelpers';
 import { getTerminalCommentPrefix } from '../runBuildCurrentSpecCommand/utils/terminalHelpers';
 
 export async function rerunLastAction(
@@ -68,6 +69,20 @@ export async function rerunLastAction(
     terminal.show();
     terminal.sendText(`${getTerminalCommentPrefix()} Dalec command: ${formattedCommand}`);
     terminal.sendText(formattedCommand);
+  } else if (actionType === 'debug') {
+    const debugConfig: vscode.DebugConfiguration = {
+      type: 'dalec-buildx',
+      name: `Dalec Debug (${entry.target})`,
+      request: 'launch',
+      target: entry.target,
+      specFile: entry.specUri.fsPath,
+      context: contextSelection.defaultContextPath,
+      buildContexts: recordFromMap(contextSelection.additionalContexts),
+      buildArgs: recordFromMap(argsSelection.values),
+      dalecContextResolved: true,
+    };
+
+    await vscode.debug.startDebugging(folder, debugConfig);
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
-import { DalecCodeLensProvider, DalecDebugAdapterDescriptorFactory, DalecDebugAdapterTrackerFactory, DalecDebugConfigurationProvider, LastDalecActionState, runBuildCommand } from './commands/runBuildCurrentSpecCommand/runBuildCommand';
+import { DalecCodeLensProvider, DalecDebugAdapterDescriptorFactory, DalecDebugAdapterTrackerFactory, DalecDebugConfigurationProvider, LastDalecActionState, runBuildCommand, runDebugCommand } from './commands/runBuildCurrentSpecCommand/runBuildCommand';
 import { DalecDocumentTracker, DalecSchemaProvider } from './commands/runBuildCurrentSpecCommand/dalecDocumentTracker';
 import { DalecStatusBarManager } from './commands/runBuildCurrentSpecCommand/dalecStatusBar';
 import { rerunLastAction } from './commands/reRunLastAction/reRunLastAction';
@@ -60,6 +60,10 @@ export async function activate(context: vscode.ExtensionContext) {
 	// The commandId parameter must match the command field in package.json
 	const disposable = vscode.commands.registerCommand('dalec-vscode-tools.buildCurrentSpec', (uri?: vscode.Uri) =>
       runBuildCommand(uri, tracker, lastAction),
+    );
+
+	vscode.commands.registerCommand('dalec-vscode-tools.debugCurrentSpec', (uri?: vscode.Uri) =>
+      runDebugCommand(uri, tracker, lastAction),
     );
 
 	vscode.commands.registerCommand('dalec-vscode-tools.rerunLastAction', () => rerunLastAction(tracker, lastAction)),


### PR DESCRIPTION
This calls `docker buildx dap build` to setup a DAP server as part of the build.
Currently the user cannot set custom breakpoints... which can be weird anyway for a declarative spec... but may add in the future. What does happen is if there is a build failure an automatic breakpoint is triggered and the debug panel gets the call stack, filesystem layout of the build, etc... basically whatevever buildx provides here.