### PR TITLE
Fix: release name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,6 @@ All notable changes to the "dalec-vscode-tools" extension will be documented in 
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [0.0.1-alpha]
+## [0.0.1]
 
 - Initial release with build and rerun last feature.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dalec-vscode-tools",
-  "version": "0.0.1-alpha",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dalec-vscode-tools",
-      "version": "0.0.1-alpha",
+      "version": "0.0.1",
       "dependencies": {
         "yaml": "^2.8.2"
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dalec-vscode-tools",
   "displayName": "DALEC VSCode Tools",
   "description": "dalec vscode extension for developers",
-  "version": "0.0.1-alpha",
+  "version": "0.0.1",
   "publisher": "ms-kubernetes-tools",
   "icon": "resources/dalec.png",
   "engines": {


### PR DESCRIPTION
Fixes the prerelease version to `major.minor.path` not hyphens `-` https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions 

Thanks 