### PR TITLE
adding initial issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,38 @@
+name: Bug Report
+description: Report a bug in Dalec VSCode Extension
+title: "[BUG] <title>"
+labels:
+  - "bug"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search to see if an issue already exists for your bug before continuing.
+        > If you need to report a security issue please see https://github.com/project-dalec/dalec-vscode-extension/security instead.
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: Briefly describe what you expect to happen.
+  - type: textarea
+    attributes:
+      label: Actual Behavior
+      description: Briefly describe what is actually happening.
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Detailed steps to reproduce the behavior.
+      placeholder: |
+        1. In ...
+        2. With this config...
+        3. Run '...'
+        4. See error...
+  - type: checkboxes
+    id: idea
+    attributes:
+      label: "Are you willing to submit PRs to contribute to this bug fix?"
+      options:
+        - label: Yes, I am willing to implement it.
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out a bug report!

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,34 @@
+name: Request
+description: Request a new feature or propose an enhancement to Dalec VSCode Extension
+title: "[REQ] <title>"
+labels:
+  - "enhancement"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search to see if an issue already exists for your request before continuing.
+  - type: dropdown
+    attributes:
+      label: What kind of request is this?
+      multiple: false
+      options:
+        - New feature
+        - Improvement of existing experience
+        - Other
+  - type: textarea
+    attributes:
+      label: What is your request or suggestion?
+      placeholder: |
+        e.g. I would like the Dalec VSCode Extension to add this <feature> so that I can use it in my <scenario>.
+        e.g. When using the Dalec VSCode Extension the <current behavior> has this <limitation> and it would be better if it has this <improvement>.
+  - type: checkboxes
+    id: idea
+    attributes:
+      label: "Are you willing to submit PRs to contribute to this feature request?"
+      options:
+        - label: Yes, I am willing to implement it.
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out a request!


### PR DESCRIPTION
**What this PR does / why we need it**:

adding initial issue templates from dalec repo https://github.com/project-dalec/dalec/tree/main/.github/ISSUE_TEMPLATE
for better UX

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

Fixes #

**Special notes for your reviewer**: