### PR TITLE
Publish release 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the "dalec-vscode-tools" extension will be documented in 
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.0.2]
+
+- Dependabots updates.
+- Sign and attest release artifacts (#57)
+- publish: Fix adding vsix to GH release artifacts (#56)
+- Adding initial issue templates (#51)
+- Re-use terminal based on document+target (#36)
+- feat: add webpack bundling support (#42)
+- Make sure last action lenses are sorted the same (#38)
+- Wire up spec resolution (#35)
+- only add tag for container targets (#39)
+
+Thank you so much @DannyBrito, @ashu8912, @cpuguy83 , @Tatsinnit for collaborations, contributions and updates.
+
 ## [0.0.1]
 
 - Initial release with build and rerun last feature.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dalec-vscode-tools",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dalec-vscode-tools",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "yaml": "^2.8.2"
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dalec-vscode-tools",
   "displayName": "DALEC VSCode Tools",
   "description": "dalec vscode extension for developers",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publisher": "ms-kubernetes-tools",
   "icon": "resources/dalec.png",
   "engines": {


### PR DESCRIPTION
This PR helps in publishing release `0.0.2` for the dalec vscode extension.

Update includes: 

- Dependabots updates.
- Sign and attest release artifacts (#57)
- publish: Fix adding vsix to GH release artifacts (#56)
- Adding initial issue templates (#51)
- Re-use terminal based on document+target (#36)
- feat: add webpack bundling support (#42)
- Make sure last action lenses are sorted the same (#38)
- Wire up spec resolution (#35)

Thank you so much @DannyBrito, @ashu8912, @cpuguy83 , @Tatsinnit for collaborations, contributions and updates.

VSIX for quick test: ❤️  If folks want to test a copy, here is the file, please avoid unzipping and jsut rename it by removing the `.zip` form the name: 
[dalec-vscode-tools-0.0.2-test.vsix.zip](https://github.com/user-attachments/files/24764629/dalec-vscode-tools-0.0.2-test.vsix.zip)


![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYm1lYjd5cW52N2d0YmM2NTNncnZ6ODR1cjU3MnRsemUxYTRwZWM4bCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/x5AlLBS6YmXUQ/giphy.gif)
