### PR TITLE
Pin actions for the workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,7 +86,7 @@ jobs:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
       - name: Sign artifacts
         run: |
           set -euo pipefail


### PR DESCRIPTION
This PR fixes the requirement for this repo to have all dependencies pinned before running them. The current dependency is pinned to https://github.com/sigstore/cosign-installer/releases/tag/v4.0.0 of `codesign` release.

🧙 Thanks and gentle fyi: @cpuguy83 , @DannyBrito , @ashu8912 